### PR TITLE
#5 : Filter Search (Like) with type date/datetime will cause Error

### DIFF
--- a/db/query.go
+++ b/db/query.go
@@ -486,7 +486,12 @@ func SetWhere(baseDB *gorm.DB, ptr reflect.Value, query url.Values) *gorm.DB {
 								}
 							}
 							if lastSubkey == QueryOptInsensitiveLike || lastSubkey == QueryOptInsensitiveNotLike {
-								column = "LOWER(" + column + ")"
+								// check if field type is date/datetime , then cast to char ( compatible with postgrest & mysql )
+								if field.Type.Name() == "NullDateTime" || field.Type.Name() == "NullDate" {
+									column = "CAST(" + column + " AS CHAR)"
+								} else {
+									column = "LOWER(" + column + ")"
+								}
 								val = strings.ToLower(val)
 							}
 							if lastSubkey == QueryOptIn || lastSubkey == QueryOptNotIn {
@@ -571,7 +576,12 @@ func SetWhere(baseDB *gorm.DB, ptr reflect.Value, query url.Values) *gorm.DB {
 											}
 										}
 										if lastSubkey == QueryOptInsensitiveLike || lastSubkey == QueryOptInsensitiveNotLike {
-											column = "lower(" + column + ")"
+											// check if field type is date/datetime , then cast to char ( compatible with postgrest & mysql )
+											if field.Type.Name() == "NullDateTime" || field.Type.Name() == "NullDate" {
+												column = "CAST(" + column + " AS CHAR)"
+											} else {
+												column = "LOWER(" + column + ")"
+											}
 											val = strings.ToLower(val)
 										}
 										if lastSubkey == QueryOptIn || lastSubkey == QueryOptNotIn {

--- a/db/query.go
+++ b/db/query.go
@@ -486,11 +486,11 @@ func SetWhere(baseDB *gorm.DB, ptr reflect.Value, query url.Values) *gorm.DB {
 								}
 							}
 							if lastSubkey == QueryOptInsensitiveLike || lastSubkey == QueryOptInsensitiveNotLike {
-								// check if field type is date/datetime , then cast to char ( compatible with postgrest & mysql )
-								if field.Type.Name() == "NullDateTime" || field.Type.Name() == "NullDate" {
-									column = "CAST(" + column + " AS CHAR)"
-								} else {
-									column = "LOWER(" + column + ")"
+								// check if field type is date/time and dialector is postgrest , then cast to char
+								if !strings.Contains(field.Type.Name(), "Date") && !strings.Contains(field.Type.Name(), "Time") {
+									column = "LOWER (" + column + ")"
+								} else if db.Dialector.Name() == "postgres" {
+									column = "CAST( " + column + " AS CHAR)"
 								}
 								val = strings.ToLower(val)
 							}
@@ -576,11 +576,11 @@ func SetWhere(baseDB *gorm.DB, ptr reflect.Value, query url.Values) *gorm.DB {
 											}
 										}
 										if lastSubkey == QueryOptInsensitiveLike || lastSubkey == QueryOptInsensitiveNotLike {
-											// check if field type is date/datetime , then cast to char ( compatible with postgrest & mysql )
-											if field.Type.Name() == "NullDateTime" || field.Type.Name() == "NullDate" {
-												column = "CAST(" + column + " AS CHAR)"
-											} else {
-												column = "LOWER(" + column + ")"
+											// check if field type is date/time and dialector is postgrest , then cast to char
+											if !strings.Contains(field.Type.Name(), "Date") && !strings.Contains(field.Type.Name(), "Time") {
+												column = "LOWER (" + column + ")"
+											} else if db.Dialector.Name() == "postgres" {
+												column = "CAST( " + column + " AS CHAR)"
 											}
 											val = strings.ToLower(val)
 										}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -80,6 +80,10 @@ func TestQueryWithAggregationSelect(t *testing.T) {
 	q := url.Values{}
 	q.Add("$select", "$count:id")
 	Find(db, &articles, q)
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("Failed to meet expectations, got error: %v", err)
+	}
 }
 
 func TestQueryWithHiddenFieldFilter(t *testing.T) {
@@ -127,5 +131,56 @@ func TestQueryWithHiddenFieldFilter(t *testing.T) {
 	articles := []Article{}
 	q := url.Values{}
 	q.Add("is_hidden", "true")
+	Find(db, &articles, q)
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("Failed to meet expectations, got error: %v", err)
+	}
+}
+
+func TestQueryWithSearchDateFilter(t *testing.T) {
+	db, mock, err := NewMockDB()
+	if err != nil {
+		t.Fatalf("Error occured : [%v]", err.Error())
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(`
+	SELECT 
+		"a"."id" AS "id",
+		"a"."title" AS "title",
+		"a"."content" AS "content",
+		"a"."author_id" AS "author.id",
+		"u"."name" AS "author.name",
+		"u"."email" AS "author.email",
+		"a"."detail" AS "detail",
+		"a"."is_active" AS "is_active",
+		"a"."created_at" AS "created_at",
+		"a"."updated_at" AS "updated_at",
+		"a"."deleted_at" AS "deleted_at"
+	FROM
+		"articles" AS "u"
+		LEFT JOIN "users" AS "u" ON "u"."id" = "a"."author_id"
+	WHERE
+		"a"."deleted_at" IS NULL AND CAST( "a"."created_at" AS CHAR) LIKE $1
+	ORDER BY
+		"a"."updated_at" DESC
+	LIMIT 10`)).
+		WithArgs("%2022%").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id",
+			"title",
+			"content",
+			"author.id",
+			"author.name",
+			"author.email",
+			"detail",
+			"is_active",
+			"created_at",
+			"updated_at",
+			"deleted_at",
+		}))
+
+	articles := []Article{}
+	q := url.Values{}
+	q.Add("$search", "created_at=2022")
 	Find(db, &articles, q)
 }

--- a/db/testing.go
+++ b/db/testing.go
@@ -1,12 +1,14 @@
 package db
 
 import (
+	"os"
+
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
-func NewMockDB(isPrintQuery ...bool) (*gorm.DB, sqlmock.Sqlmock, error) {
+func NewMockDB() (*gorm.DB, sqlmock.Sqlmock, error) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		return nil, mock, err
@@ -18,7 +20,7 @@ func NewMockDB(isPrintQuery ...bool) (*gorm.DB, sqlmock.Sqlmock, error) {
 			PreferSimpleProtocol: true,
 		},
 	), &gorm.Config{})
-	if len(isPrintQuery) > 0 && isPrintQuery[0] {
+	if os.Getenv("IS_PRINT_SQL") == "true" {
 		gormDB = gormDB.Debug()
 	}
 	return gormDB, mock, err


### PR DESCRIPTION
Because there is no lower function in the date / time data type.
then the solution is to change the data type before operator LIKE.
i prefer use CHAR , because there is no varchar type in mysql (Ref : https://www.w3schools.com/sql/func_mysql_cast.asp)


generated query : **CAST("a"."date" AS CHAR) LIKE '%2021%'**