### PR TITLE
#24 - Join table relations with condition 'value' are not parsed

### DIFF
--- a/db_query.go
+++ b/db_query.go
@@ -368,7 +368,9 @@ func (q *DBQuery) SetJoin(db *gorm.DB, schema map[string]any, query url.Values) 
 					if len(cond) > 0 {
 						joinCondition, arg := q.condToWhereSQL(cond)
 						joinConditions = append(joinConditions, joinCondition)
-						args = append(args, arg)
+						if arg != nil {
+							args = append(args, arg)
+						}
 					}
 				}
 


### PR DESCRIPTION
tested : 

```
...
	//default employee
	c.AddRelation("left", "other_fields", "of_employee", []map[string]any{{"column1": "of_employee.data_id", "column2": "c.contact_id"}, {"column1": "of_employee.key", "value": "default.salesman"}, {"column1": "of_employee.value", "operator": "!=", "value": nil}})
....
```

generated query : 
```
...
LEFT JOIN "other_fields" AS "of_employee" ON "of_employee"."data_id" = "c"."contact_id" 
	AND "of_employee"."value" IS NOT NULL 
	AND "of_employee"."key" = 'default.salesman'
...
```
