### PR TITLE
#30 RelationOrders & fields cloned everytime called func GetSchema()

### DIFF
--- a/model.go
+++ b/model.go
@@ -176,9 +176,6 @@ func (m *Model) SetFields(p any) {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		if jsonTag, _, _ := strings.Cut(field.Tag.Get("json"), ","); jsonTag != "" && jsonTag != "-" {
-			if _, exists := m.Fields[jsonTag]; exists {
-				continue
-			}
 			isHide := false
 			isGroup := false
 			dbTag := field.Tag.Get("db")
@@ -257,7 +254,9 @@ func (m *Model) AddField(fieldKey string, fieldOpt map[string]any) {
 	} else {
 		m.Fields = map[string]map[string]any{fieldKey: fieldOpt}
 	}
-	m.FieldOrder = append(m.FieldOrder, fieldKey)
+	if !contains(m.FieldOrder, fieldKey) {
+		m.FieldOrder = append(m.FieldOrder, fieldKey)
+	}
 }
 
 // GetFields returns the model fields.

--- a/model.go
+++ b/model.go
@@ -176,6 +176,9 @@ func (m *Model) SetFields(p any) {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		if jsonTag, _, _ := strings.Cut(field.Tag.Get("json"), ","); jsonTag != "" && jsonTag != "-" {
+			if _, exists := m.Fields[jsonTag]; exists {
+				continue
+			}
 			isHide := false
 			isGroup := false
 			dbTag := field.Tag.Get("db")
@@ -341,7 +344,18 @@ func (m *Model) AddRelation(joinType string, tableName any, tableAliasName strin
 	} else {
 		m.Relations = map[string]map[string]any{tableAliasName: relation}
 	}
-	m.RelationOrder = append(m.RelationOrder, tableAliasName)
+	if !contains(m.RelationOrder, tableAliasName) {
+		m.RelationOrder = append(m.RelationOrder, tableAliasName)
+	}
+}
+
+func contains(slice []string, value string) bool {
+	for _, v := range slice {
+		if v == value {
+			return true
+		}
+	}
+	return false
 }
 
 // GetRelations returns the model relations., expected key :


### PR DESCRIPTION
Modifiy model.go 

- add new func 
``` go 
func contains(slice []string, value string) bool {
	for _, v := range slice {
		if v == value {
			return true
		}
	}
	return false
}
```

- edited func 
``` go 
func (m *Model) AddRelation(joinType string, tableName any, tableAliasName string, conditions []map[string]any) {
	relation := map[string]any{
		"tableName":      tableName,
		"tableAliasName": tableAliasName,
		"type":           joinType,
		"conditions":     conditions,
	}
	tableSchema, isSchema := tableName.(map[string]any)
	if isSchema {
		relation["tableSchema"] = tableSchema
	}
	if m.Relations != nil {
		m.Relations[tableAliasName] = relation
	} else {
		m.Relations = map[string]map[string]any{tableAliasName: relation}
	}

> 	if !contains(m.RelationOrder, tableAliasName) {
> 		m.RelationOrder = append(m.RelationOrder, tableAliasName)
> 	}

}
```

``` go 
func (m *Model) SetFields(p any) {
	ptr := reflect.ValueOf(p)
	t := ptr.Elem().Type()
	for i := 0; i < t.NumField(); i++ {
		field := t.Field(i)
		if jsonTag, _, _ := strings.Cut(field.Tag.Get("json"), ","); jsonTag != "" && jsonTag != "-" {

> 			if _, exists := m.Fields[jsonTag]; exists {
> 				continue
> 			}

			isHide := false
			isGroup := false
....
```

- Add new func in model_test.go as test func